### PR TITLE
chore: scope private and intranet subnet nacl to vpc cidr

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .terraform/*
+.idea

--- a/nacl.tf
+++ b/nacl.tf
@@ -192,31 +192,42 @@ resource "aws_network_acl_rule" "private_inbound_rdp_rule_deny" {
   count          = local.create_private ? 1 : 0
   network_acl_id = aws_network_acl.private[0].id
   cidr_block     = "0.0.0.0/0"
-  rule_number    = 105
+  rule_number    = 110
   protocol       = "tcp"
   from_port      = 3389
   to_port        = 3389
   rule_action    = "deny"
+}
+
+resource "aws_network_acl_rule" "private_outbound_rdp_rule_deny" {
+  count          = local.create_private ? 1 : 0
+  network_acl_id = aws_network_acl.private[0].id
+  rule_number    = 110
+  cidr_block     = "0.0.0.0/0"
+  protocol       = "tcp"
+  from_port      = 3389
+  to_port        = 3389
+  rule_action    = "deny"
+  egress         = true
 }
 
 resource "aws_network_acl_rule" "private_inbound_rdp_rule_deny_udp" {
   count          = local.create_private ? 1 : 0
   network_acl_id = aws_network_acl.private[0].id
   cidr_block     = "0.0.0.0/0"
-  rule_number    = 106
+  rule_number    = 120
   protocol       = "udp"
   from_port      = 3389
   to_port        = 3389
   rule_action    = "deny"
 }
 
-
-resource "aws_network_acl_rule" "private_outbound_rdp_rule_deny" {
+resource "aws_network_acl_rule" "private_outbound_rdp_rule_deny_udp" {
   count          = local.create_private ? 1 : 0
   network_acl_id = aws_network_acl.private[0].id
-  rule_number    = 105
+  rule_number    = 120
   cidr_block     = "0.0.0.0/0"
-  protocol       = "tcp"
+  protocol       = "udp"
   from_port      = 3389
   to_port        = 3389
   rule_action    = "deny"
@@ -226,7 +237,7 @@ resource "aws_network_acl_rule" "private_outbound_rdp_rule_deny" {
 resource "aws_network_acl_rule" "private_inbound_allow_80_rule" {
   count          = local.create_private ? 1 : 0
   network_acl_id = aws_network_acl.private[0].id
-  rule_number    = 109
+  rule_number    = 200
   cidr_block     = "0.0.0.0/0"
   protocol       = "tcp"
   from_port      = 80
@@ -237,7 +248,7 @@ resource "aws_network_acl_rule" "private_inbound_allow_80_rule" {
 resource "aws_network_acl_rule" "private_outbound_allow_80_rule" {
   count          = local.create_private ? 1 : 0
   network_acl_id = aws_network_acl.private[0].id
-  rule_number    = 109
+  rule_number    = 200
   cidr_block     = "0.0.0.0/0"
   protocol       = "tcp"
   from_port      = 80
@@ -249,7 +260,7 @@ resource "aws_network_acl_rule" "private_outbound_allow_80_rule" {
 resource "aws_network_acl_rule" "private_inbound_allow_443_rule" {
   count          = local.create_private ? 1 : 0
   network_acl_id = aws_network_acl.private[0].id
-  rule_number    = 110
+  rule_number    = 210
   cidr_block     = "0.0.0.0/0"
   protocol       = "tcp"
   from_port      = 443
@@ -260,7 +271,7 @@ resource "aws_network_acl_rule" "private_inbound_allow_443_rule" {
 resource "aws_network_acl_rule" "private_outbound_allow_443_rule" {
   count          = local.create_private ? 1 : 0
   network_acl_id = aws_network_acl.private[0].id
-  rule_number    = 110
+  rule_number    = 210
   cidr_block     = "0.0.0.0/0"
   protocol       = "tcp"
   from_port      = 443
@@ -272,7 +283,7 @@ resource "aws_network_acl_rule" "private_outbound_allow_443_rule" {
 resource "aws_network_acl_rule" "private_inbound_nfs_111_rule" {
   count          = local.create_private ? 1 : 0
   network_acl_id = aws_network_acl.private[0].id
-  rule_number    = 115
+  rule_number    = 220
   cidr_block     = module.vpc.vpc_cidr_block
   protocol       = "tcp"
   from_port      = 111
@@ -283,7 +294,7 @@ resource "aws_network_acl_rule" "private_inbound_nfs_111_rule" {
 resource "aws_network_acl_rule" "private_outbound_nfs_111_rule" {
   count          = local.create_private ? 1 : 0
   network_acl_id = aws_network_acl.private[0].id
-  rule_number    = 115
+  rule_number    = 220
   cidr_block     = module.vpc.vpc_cidr_block
   protocol       = "tcp"
   from_port      = 111
@@ -295,7 +306,7 @@ resource "aws_network_acl_rule" "private_outbound_nfs_111_rule" {
 resource "aws_network_acl_rule" "private_inbound_nfs_111_rule_secondary_cidr" {
   count          = local.create_private ? length(var.secondary_cidr_blocks) : 0
   network_acl_id = aws_network_acl.private[0].id
-  rule_number    = 116 + count.index
+  rule_number    = 230 + count.index
   cidr_block     = var.secondary_cidr_blocks[count.index]
   protocol       = "tcp"
   from_port      = 111
@@ -306,7 +317,7 @@ resource "aws_network_acl_rule" "private_inbound_nfs_111_rule_secondary_cidr" {
 resource "aws_network_acl_rule" "private_outbound_nfs_111_rule_secondary_cidr" {
   count          = local.create_private ? length(var.secondary_cidr_blocks) : 0
   network_acl_id = aws_network_acl.private[0].id
-  rule_number    = 116 + count.index
+  rule_number    = 230 + count.index
   cidr_block     = var.secondary_cidr_blocks[count.index]
   protocol       = "tcp"
   from_port      = 111
@@ -318,7 +329,7 @@ resource "aws_network_acl_rule" "private_outbound_nfs_111_rule_secondary_cidr" {
 resource "aws_network_acl_rule" "private_inbound_ssh_rule" {
   count          = local.create_private ? 1 : 0
   network_acl_id = aws_network_acl.private[0].id
-  rule_number    = 120
+  rule_number    = 240
   cidr_block     = module.vpc.vpc_cidr_block
   protocol       = "tcp"
   from_port      = 22
@@ -329,7 +340,7 @@ resource "aws_network_acl_rule" "private_inbound_ssh_rule" {
 resource "aws_network_acl_rule" "private_outbound_ssh_rule" {
   count          = local.create_private ? 1 : 0
   network_acl_id = aws_network_acl.private[0].id
-  rule_number    = 120
+  rule_number    = 240
   cidr_block     = module.vpc.vpc_cidr_block
   protocol       = "tcp"
   from_port      = 22
@@ -341,7 +352,7 @@ resource "aws_network_acl_rule" "private_outbound_ssh_rule" {
 resource "aws_network_acl_rule" "private_inbound_ssh_rule_secondary_cidr" {
   count          = local.create_private ? length(var.secondary_cidr_blocks) : 0
   network_acl_id = aws_network_acl.private[0].id
-  rule_number    = 121 + count.index
+  rule_number    = 250 + count.index
   cidr_block     = var.secondary_cidr_blocks[count.index]
   protocol       = "tcp"
   from_port      = 22
@@ -352,7 +363,7 @@ resource "aws_network_acl_rule" "private_inbound_ssh_rule_secondary_cidr" {
 resource "aws_network_acl_rule" "private_outbound_ssh_rule_secondary_cidr" {
   count          = local.create_private ? length(var.secondary_cidr_blocks) : 0
   network_acl_id = aws_network_acl.private[0].id
-  rule_number    = 121 + count.index
+  rule_number    = 250 + count.index
   cidr_block     = var.secondary_cidr_blocks[count.index]
   protocol       = "tcp"
   from_port      = 22
@@ -364,7 +375,7 @@ resource "aws_network_acl_rule" "private_outbound_ssh_rule_secondary_cidr" {
 resource "aws_network_acl_rule" "private_inbound_ldap_rule" {
   count          = local.create_private ? 1 : 0
   network_acl_id = aws_network_acl.private[0].id
-  rule_number    = 125
+  rule_number    = 260
   cidr_block     = module.vpc.vpc_cidr_block
   protocol       = "tcp"
   from_port      = 389
@@ -375,7 +386,7 @@ resource "aws_network_acl_rule" "private_inbound_ldap_rule" {
 resource "aws_network_acl_rule" "private_outbound_ldap_rule" {
   count          = local.create_private ? 1 : 0
   network_acl_id = aws_network_acl.private[0].id
-  rule_number    = 125
+  rule_number    = 260
   cidr_block     = module.vpc.vpc_cidr_block
   protocol       = "tcp"
   from_port      = 389
@@ -387,7 +398,7 @@ resource "aws_network_acl_rule" "private_outbound_ldap_rule" {
 resource "aws_network_acl_rule" "private_inbound_ldap_rule_secondary_cidr" {
   count          = local.create_private ? length(var.secondary_cidr_blocks) : 0
   network_acl_id = aws_network_acl.private[0].id
-  rule_number    = 126 + count.index
+  rule_number    = 270 + count.index
   cidr_block     = var.secondary_cidr_blocks[count.index]
   protocol       = "tcp"
   from_port      = 389
@@ -398,7 +409,7 @@ resource "aws_network_acl_rule" "private_inbound_ldap_rule_secondary_cidr" {
 resource "aws_network_acl_rule" "private_outbound_ldap_rule_secondary_cidr" {
   count          = local.create_private ? length(var.secondary_cidr_blocks) : 0
   network_acl_id = aws_network_acl.private[0].id
-  rule_number    = 126 + count.index
+  rule_number    = 270 + count.index
   cidr_block     = var.secondary_cidr_blocks[count.index]
   protocol       = "tcp"
   from_port      = 389
@@ -410,7 +421,7 @@ resource "aws_network_acl_rule" "private_outbound_ldap_rule_secondary_cidr" {
 resource "aws_network_acl_rule" "private_inbound_openvpn_rule" {
   count          = local.create_private ? 1 : 0
   network_acl_id = aws_network_acl.private[0].id
-  rule_number    = 135
+  rule_number    = 280
   cidr_block     = module.vpc.vpc_cidr_block
   protocol       = "tcp"
   from_port      = 943
@@ -421,8 +432,31 @@ resource "aws_network_acl_rule" "private_inbound_openvpn_rule" {
 resource "aws_network_acl_rule" "private_outbound_openvpn_rule" {
   count          = local.create_private ? 1 : 0
   network_acl_id = aws_network_acl.private[0].id
-  rule_number    = 135
+  rule_number    = 280
   cidr_block     = module.vpc.vpc_cidr_block
+  protocol       = "tcp"
+  from_port      = 943
+  to_port        = 943
+  rule_action    = "allow"
+  egress         = true
+}
+
+resource "aws_network_acl_rule" "private_inbound_openvpn_rule_secondary_cidr" {
+  count          = local.create_private ? length(var.secondary_cidr_blocks) : 0
+  network_acl_id = aws_network_acl.private[0].id
+  rule_number    = 290 + count.index
+  cidr_block     = var.secondary_cidr_blocks[count.index]
+  protocol       = "tcp"
+  from_port      = 943
+  to_port        = 943
+  rule_action    = "allow"
+}
+
+resource "aws_network_acl_rule" "private_outbound_openvpn_rule_secondary_cidr" {
+  count          = local.create_private ? length(var.secondary_cidr_blocks) : 0
+  network_acl_id = aws_network_acl.private[0].id
+  rule_number    = 290 + count.index
+  cidr_block     = var.secondary_cidr_blocks[count.index]
   protocol       = "tcp"
   from_port      = 943
   to_port        = 943
@@ -434,7 +468,7 @@ resource "aws_network_acl_rule" "private_inbound_ssh_rule_deny" {
   count          = local.create_private ? 1 : 0
   network_acl_id = aws_network_acl.private[0].id
   cidr_block     = "0.0.0.0/0"
-  rule_number    = 139
+  rule_number    = 300
   protocol       = "tcp"
   from_port      = 22
   to_port        = 22
@@ -444,7 +478,7 @@ resource "aws_network_acl_rule" "private_inbound_ssh_rule_deny" {
 resource "aws_network_acl_rule" "private_outbound_ssh_rule_deny" {
   count          = local.create_private ? 1 : 0
   network_acl_id = aws_network_acl.private[0].id
-  rule_number    = 139
+  rule_number    = 300
   cidr_block     = "0.0.0.0/0"
   protocol       = "tcp"
   from_port      = 22
@@ -453,125 +487,10 @@ resource "aws_network_acl_rule" "private_outbound_ssh_rule_deny" {
   egress         = true
 }
 
-resource "aws_network_acl_rule" "private_inbound_openvpn_rule_secondary_cidr" {
-  count          = local.create_private ? length(var.secondary_cidr_blocks) : 0
-  network_acl_id = aws_network_acl.private[0].id
-  rule_number    = 136 + count.index
-  cidr_block     = var.secondary_cidr_blocks[count.index]
-  protocol       = "tcp"
-  from_port      = 943
-  to_port        = 943
-  rule_action    = "allow"
-}
-
-resource "aws_network_acl_rule" "private_outbound_openvpn_rule_secondary_cidr" {
-  count          = local.create_private ? length(var.secondary_cidr_blocks) : 0
-  network_acl_id = aws_network_acl.private[0].id
-  rule_number    = 136 + count.index
-  cidr_block     = var.secondary_cidr_blocks[count.index]
-  protocol       = "tcp"
-  from_port      = 943
-  to_port        = 943
-  rule_action    = "allow"
-  egress         = true
-}
-
-resource "aws_network_acl_rule" "private_inbound_allow_all_ephemeral_rule" {
-  count          = local.create_private ? 1 : 0
-  network_acl_id = aws_network_acl.private[0].id
-  rule_number    = 140
-  cidr_block     = "0.0.0.0/0"
-  protocol       = "tcp"
-  from_port      = 700
-  to_port        = 65535
-  rule_action    = "allow"
-}
-
-resource "aws_network_acl_rule" "private_outbound_allow_all_ephemeral_rule" {
-  count          = local.create_private ? 1 : 0
-  network_acl_id = aws_network_acl.private[0].id
-  rule_number    = 140
-  cidr_block     = module.vpc.vpc_cidr_block
-  protocol       = "tcp"
-  from_port      = 700
-  to_port        = 65535
-  rule_action    = "allow"
-  egress         = "true"
-}
-
-resource "aws_network_acl_rule" "private_inbound_allow_all_udp" {
-  count          = local.create_private ? 1 : 0
-  network_acl_id = aws_network_acl.private[0].id
-  rule_number    = 141
-  cidr_block     = module.vpc.vpc_cidr_block
-  protocol       = "udp"
-  from_port      = 1
-  to_port        = 65535
-  rule_action    = "allow"
-}
-
-resource "aws_network_acl_rule" "private_outbound_allow_all_udp" {
-  count          = local.create_private ? 1 : 0
-  network_acl_id = aws_network_acl.private[0].id
-  rule_number    = 141
-  cidr_block     = module.vpc.vpc_cidr_block
-  protocol       = "udp"
-  from_port      = 1
-  to_port        = 65535
-  rule_action    = "allow"
-  egress         = "true"
-}
-
-resource "aws_network_acl_rule" "private_inbound_allow_all_udp_secondary_cidr" {
-  count          = local.create_private ? length(var.secondary_cidr_blocks) : 0
-  network_acl_id = aws_network_acl.private[0].id
-  rule_number    = 142 + count.index
-  cidr_block     = var.secondary_cidr_blocks[count.index]
-  protocol       = "udp"
-  from_port      = 1
-  to_port        = 65535
-  rule_action    = "allow"
-}
-
-resource "aws_network_acl_rule" "private_outbound_allow_all_udp_secondary_cidr" {
-  count          = local.create_private ? length(var.secondary_cidr_blocks) : 0
-  network_acl_id = aws_network_acl.private[0].id
-  rule_number    = 142 + count.index
-  cidr_block     = var.secondary_cidr_blocks[count.index]
-  protocol       = "udp"
-  from_port      = 1
-  to_port        = 65535
-  rule_action    = "allow"
-  egress         = "true"
-}
-
-resource "aws_network_acl_rule" "private_inbound_allow_tcp_dns" {
-  count          = local.create_private ? 1 : 0
-  network_acl_id = aws_network_acl.private[0].id
-  rule_number    = 147
-  cidr_block     = "0.0.0.0/0"
-  protocol       = "tcp"
-  from_port      = 53
-  to_port        = 53
-  rule_action    = "allow"
-}
-
-resource "aws_network_acl_rule" "private_outbound_allow_tcp_dns" {
-  count          = local.create_private ? 1 : 0
-  network_acl_id = aws_network_acl.private[0].id
-  rule_number    = 147
-  cidr_block     = "0.0.0.0/0"
-  protocol       = "tcp"
-  from_port      = 53
-  to_port        = 53
-  rule_action    = "allow"
-  egress         = "true"
-}
-
 resource "aws_network_acl_rule" "private_inbound_allow_smtp_rule" {
   count          = local.create_private ? 1 : 0
   network_acl_id = aws_network_acl.private[0].id
-  rule_number    = 150
+  rule_number    = 900
   cidr_block     = "0.0.0.0/0"
   protocol       = "tcp"
   from_port      = 587
@@ -582,7 +501,7 @@ resource "aws_network_acl_rule" "private_inbound_allow_smtp_rule" {
 resource "aws_network_acl_rule" "private_outbound_allow_smtp_rule" {
   count          = local.create_private ? 1 : 0
   network_acl_id = aws_network_acl.private[0].id
-  rule_number    = 150
+  rule_number    = 900
   cidr_block     = "0.0.0.0/0"
   protocol       = "tcp"
   from_port      = 587
@@ -594,7 +513,7 @@ resource "aws_network_acl_rule" "private_outbound_allow_smtp_rule" {
 resource "aws_network_acl_rule" "private_inbound_allow_bgp_179_rule" {
   count          = local.create_private ? 1 : 0
   network_acl_id = aws_network_acl.private[0].id
-  rule_number    = 153
+  rule_number    = 910
   cidr_block     = module.vpc.vpc_cidr_block
   protocol       = "tcp"
   from_port      = 179
@@ -605,7 +524,7 @@ resource "aws_network_acl_rule" "private_inbound_allow_bgp_179_rule" {
 resource "aws_network_acl_rule" "private_outbound_allow_bgp_179_rule" {
   count          = local.create_private ? 1 : 0
   network_acl_id = aws_network_acl.private[0].id
-  rule_number    = 153
+  rule_number    = 910
   cidr_block     = module.vpc.vpc_cidr_block
   protocol       = "tcp"
   from_port      = 179
@@ -617,7 +536,7 @@ resource "aws_network_acl_rule" "private_outbound_allow_bgp_179_rule" {
 resource "aws_network_acl_rule" "private_inbound_allow_bgp_179_secondary_cidr" {
   count          = local.create_private ? length(var.secondary_cidr_blocks) : 0
   network_acl_id = aws_network_acl.private[0].id
-  rule_number    = 154 + count.index
+  rule_number    = 920 + count.index
   cidr_block     = var.secondary_cidr_blocks[count.index]
   protocol       = "tcp"
   from_port      = 179
@@ -628,13 +547,128 @@ resource "aws_network_acl_rule" "private_inbound_allow_bgp_179_secondary_cidr" {
 resource "aws_network_acl_rule" "private_outbound_allow_bgp_179_secondary_cidr" {
   count          = local.create_private ? length(var.secondary_cidr_blocks) : 0
   network_acl_id = aws_network_acl.private[0].id
-  rule_number    = 154 + count.index
+  rule_number    = 920 + count.index
   cidr_block     = var.secondary_cidr_blocks[count.index]
   protocol       = "tcp"
   from_port      = 179
   to_port        = 179
   rule_action    = "allow"
   egress         = true
+}
+
+resource "aws_network_acl_rule" "private_inbound_allow_all_ephemeral_rule" {
+  count          = local.create_private ? 1 : 0
+  network_acl_id = aws_network_acl.private[0].id
+  rule_number    = 1100
+  cidr_block     = "0.0.0.0/0"
+  protocol       = "tcp"
+  from_port      = 700
+  to_port        = 65535
+  rule_action    = "allow"
+}
+
+resource "aws_network_acl_rule" "private_outbound_allow_all_ephemeral_rule" {
+  count          = local.create_private ? 1 : 0
+  network_acl_id = aws_network_acl.private[0].id
+  rule_number    = 1100
+  cidr_block     = module.vpc.vpc_cidr_block
+  protocol       = "tcp"
+  from_port      = 700
+  to_port        = 65535
+  rule_action    = "allow"
+  egress         = "true"
+}
+
+resource "aws_network_acl_rule" "private_inbound_allow_all_ephemeral_rule_secondary_cidr" {
+  count          = local.create_private ? length(var.secondary_cidr_blocks) : 0
+  network_acl_id = aws_network_acl.private[0].id
+  rule_number    = 1110 + count.index
+  cidr_block     = var.secondary_cidr_blocks[count.index]
+  protocol       = "tcp"
+  from_port      = 700
+  to_port        = 65535
+  rule_action    = "allow"
+}
+
+resource "aws_network_acl_rule" "private_outbound_allow_all_ephemeral_rule_secondary_cidr" {
+  count          = local.create_private ? length(var.secondary_cidr_blocks) : 0
+  network_acl_id = aws_network_acl.private[0].id
+  rule_number    = 1110 + count.index
+  cidr_block     = var.secondary_cidr_blocks[count.index]
+  protocol       = "tcp"
+  from_port      = 700
+  to_port        = 65535
+  rule_action    = "allow"
+  egress         = "true"
+}
+
+resource "aws_network_acl_rule" "private_inbound_allow_all_udp" {
+  count          = local.create_private ? 1 : 0
+  network_acl_id = aws_network_acl.private[0].id
+  rule_number    = 1000
+  cidr_block     = module.vpc.vpc_cidr_block
+  protocol       = "udp"
+  from_port      = 1
+  to_port        = 65535
+  rule_action    = "allow"
+}
+
+resource "aws_network_acl_rule" "private_outbound_allow_all_udp" {
+  count          = local.create_private ? 1 : 0
+  network_acl_id = aws_network_acl.private[0].id
+  rule_number    = 1000
+  cidr_block     = module.vpc.vpc_cidr_block
+  protocol       = "udp"
+  from_port      = 1
+  to_port        = 65535
+  rule_action    = "allow"
+  egress         = "true"
+}
+
+resource "aws_network_acl_rule" "private_inbound_allow_all_udp_secondary_cidr" {
+  count          = local.create_private ? length(var.secondary_cidr_blocks) : 0
+  network_acl_id = aws_network_acl.private[0].id
+  rule_number    = 1100 + count.index
+  cidr_block     = var.secondary_cidr_blocks[count.index]
+  protocol       = "udp"
+  from_port      = 1
+  to_port        = 65535
+  rule_action    = "allow"
+}
+
+resource "aws_network_acl_rule" "private_outbound_allow_all_udp_secondary_cidr" {
+  count          = local.create_private ? length(var.secondary_cidr_blocks) : 0
+  network_acl_id = aws_network_acl.private[0].id
+  rule_number    = 1100 + count.index
+  cidr_block     = var.secondary_cidr_blocks[count.index]
+  protocol       = "udp"
+  from_port      = 1
+  to_port        = 65535
+  rule_action    = "allow"
+  egress         = "true"
+}
+
+resource "aws_network_acl_rule" "private_inbound_allow_tcp_dns" {
+  count          = local.create_private ? 1 : 0
+  network_acl_id = aws_network_acl.private[0].id
+  rule_number    = 1200
+  cidr_block     = "0.0.0.0/0"
+  protocol       = "tcp"
+  from_port      = 53
+  to_port        = 53
+  rule_action    = "allow"
+}
+
+resource "aws_network_acl_rule" "private_outbound_allow_tcp_dns" {
+  count          = local.create_private ? 1 : 0
+  network_acl_id = aws_network_acl.private[0].id
+  rule_number    = 1200
+  cidr_block     = "0.0.0.0/0"
+  protocol       = "tcp"
+  from_port      = 53
+  to_port        = 53
+  rule_action    = "allow"
+  egress         = "true"
 }
 
 ###########################

--- a/nacl.tf
+++ b/nacl.tf
@@ -63,7 +63,7 @@ resource "aws_network_acl_rule" "public_inbound_rdp_rule_deny" {
   count          = local.create_public ? 1 : 0
   network_acl_id = aws_network_acl.public[0].id
   cidr_block     = "0.0.0.0/0"
-  rule_number    = 105
+  rule_number    = 110
   protocol       = "tcp"
   from_port      = 3389
   to_port        = 3389
@@ -74,7 +74,7 @@ resource "aws_network_acl_rule" "public_inbound_rdp_rule_deny_udp" {
   count          = local.create_public ? 1 : 0
   network_acl_id = aws_network_acl.public[0].id
   cidr_block     = "0.0.0.0/0"
-  rule_number    = 106
+  rule_number    = 120
   protocol       = "udp"
   from_port      = 3389
   to_port        = 3389
@@ -84,7 +84,7 @@ resource "aws_network_acl_rule" "public_inbound_rdp_rule_deny_udp" {
 resource "aws_network_acl_rule" "public_outbound_rdp_rule_deny" {
   count          = local.create_public ? 1 : 0
   network_acl_id = aws_network_acl.public[0].id
-  rule_number    = 105
+  rule_number    = 110
   cidr_block     = "0.0.0.0/0"
   protocol       = "tcp"
   from_port      = 3389
@@ -96,7 +96,7 @@ resource "aws_network_acl_rule" "public_outbound_rdp_rule_deny" {
 resource "aws_network_acl_rule" "public_inbound_ssh_rule" {
   count          = local.create_public ? 1 : 0
   network_acl_id = aws_network_acl.public[0].id
-  rule_number    = 120
+  rule_number    = 130
   cidr_block     = module.vpc.vpc_cidr_block
   protocol       = "tcp"
   from_port      = 22
@@ -107,7 +107,7 @@ resource "aws_network_acl_rule" "public_inbound_ssh_rule" {
 resource "aws_network_acl_rule" "public_outbound_ssh_rule" {
   count          = local.create_public ? 1 : 0
   network_acl_id = aws_network_acl.public[0].id
-  rule_number    = 120
+  rule_number    = 130
   cidr_block     = module.vpc.vpc_cidr_block
   protocol       = "tcp"
   from_port      = 22
@@ -119,7 +119,7 @@ resource "aws_network_acl_rule" "public_outbound_ssh_rule" {
 resource "aws_network_acl_rule" "public_inbound_ssh_rule_secondary_cidr" {
   count          = local.create_public ? length(var.secondary_cidr_blocks) : 0
   network_acl_id = aws_network_acl.public[0].id
-  rule_number    = 121 + count.index
+  rule_number    = 140 + count.index
   cidr_block     = var.secondary_cidr_blocks[count.index]
   protocol       = "tcp"
   from_port      = 22
@@ -130,7 +130,7 @@ resource "aws_network_acl_rule" "public_inbound_ssh_rule_secondary_cidr" {
 resource "aws_network_acl_rule" "public_outbound_ssh_rule_secondary_cidr" {
   count          = local.create_public ? length(var.secondary_cidr_blocks) : 0
   network_acl_id = aws_network_acl.public[0].id
-  rule_number    = 121 + count.index
+  rule_number    = 140 + count.index
   cidr_block     = var.secondary_cidr_blocks[count.index]
   protocol       = "tcp"
   from_port      = 22
@@ -143,7 +143,7 @@ resource "aws_network_acl_rule" "public_inbound_ssh_rule_deny" {
   count          = local.create_public ? 1 : 0
   network_acl_id = aws_network_acl.public[0].id
   cidr_block     = "0.0.0.0/0"
-  rule_number    = 139
+  rule_number    = 150
   protocol       = "tcp"
   from_port      = 22
   to_port        = 22
@@ -153,7 +153,7 @@ resource "aws_network_acl_rule" "public_inbound_ssh_rule_deny" {
 resource "aws_network_acl_rule" "public_outbound_ssh_rule_deny" {
   count          = local.create_public ? 1 : 0
   network_acl_id = aws_network_acl.public[0].id
-  rule_number    = 139
+  rule_number    = 150
   cidr_block     = "0.0.0.0/0"
   protocol       = "tcp"
   from_port      = 22
@@ -165,7 +165,7 @@ resource "aws_network_acl_rule" "public_outbound_ssh_rule_deny" {
 resource "aws_network_acl_rule" "public_inbound_allow_all_rule" {
   count          = local.create_public ? 1 : 0
   network_acl_id = aws_network_acl.public[0].id
-  rule_number    = 140
+  rule_number    = 160
   cidr_block     = "0.0.0.0/0"
   protocol       = "tcp"
   from_port      = 1
@@ -176,7 +176,7 @@ resource "aws_network_acl_rule" "public_inbound_allow_all_rule" {
 resource "aws_network_acl_rule" "public_outbound_allow_all_rule" {
   count          = local.create_public ? 1 : 0
   network_acl_id = aws_network_acl.public[0].id
-  rule_number    = 140
+  rule_number    = 160
   cidr_block     = "0.0.0.0/0"
   protocol       = "tcp"
   from_port      = 1

--- a/nacl.tf
+++ b/nacl.tf
@@ -986,6 +986,26 @@ resource "aws_network_acl_rule" "intra_outbound_allow_all_ephemeral_rule_seconda
   egress         = "true"
 }
 
+# To allow traffic between VPCs connected to a transit gateway, you need to open the necessary ports in the
+# security groups attached to the network interfaces in those VPCs.
+# The key ports required for transit gateway connectivity are:
+# - Port 443 for HTTPS communication between the VPCs and transit gateway control plane.
+# - Port 2049 for NFS traffic if you enable file sharing using NFS.
+# - Ports from 32768 to 61000 for Generic Routing Encapsulation (GRE) tunnels if you use appliance mode.
+#     Appliance mode allows you to deploy virtual appliances for functions like routing,
+#     firewalling etc across connected VPCs.
+resource "aws_network_acl_rule" "intra_outbound_allow_all_ephemeral_rule_tgw" {
+  count          = local.create_intranet ? 1 : 0
+  network_acl_id = aws_network_acl.intra[0].id
+  rule_number    = 1150
+  cidr_block     = "0.0.0.0/0"
+  protocol       = "tcp"
+  from_port      = 32768
+  to_port        = 61000
+  rule_action    = "allow"
+  egress         = "true"
+}
+
 resource "aws_network_acl_rule" "intra_inbound_allow_tcp_dns" {
   count          = local.create_intranet ? 1 : 0
   network_acl_id = aws_network_acl.intra[0].id

--- a/nacl.tf
+++ b/nacl.tf
@@ -1004,17 +1004,17 @@ resource "aws_network_acl_rule" "database_inbound_rdp_rule_deny" {
   count          = local.create_database ? 1 : 0
   network_acl_id = aws_network_acl.database[0].id
   cidr_block     = "0.0.0.0/0"
-  rule_number    = 105
+  rule_number    = 110
   protocol       = "tcp"
   from_port      = 3389
   to_port        = 3389
   rule_action    = "deny"
 }
 
-resource "aws_network_acl_rule" "database" {
+resource "aws_network_acl_rule" "database_outbound_rdp_rule_deny" {
   count          = local.create_database ? 1 : 0
   network_acl_id = aws_network_acl.database[0].id
-  rule_number    = 105
+  rule_number    = 110
   cidr_block     = "0.0.0.0/0"
   protocol       = "tcp"
   from_port      = 3389
@@ -1023,10 +1023,33 @@ resource "aws_network_acl_rule" "database" {
   egress         = true
 }
 
+resource "aws_network_acl_rule" "database_inbound_ssh_rule_deny" {
+  count          = local.create_database ? 1 : 0
+  network_acl_id = aws_network_acl.database[0].id
+  cidr_block     = "0.0.0.0/0"
+  rule_number    = 120
+  protocol       = "tcp"
+  from_port      = 22
+  to_port        = 22
+  rule_action    = "deny"
+}
+
+resource "aws_network_acl_rule" "database_outbound_ssh_rule_deny" {
+  count          = local.create_database ? 1 : 0
+  network_acl_id = aws_network_acl.database[0].id
+  rule_number    = 120
+  cidr_block     = "0.0.0.0/0"
+  protocol       = "tcp"
+  from_port      = 22
+  to_port        = 22
+  rule_action    = "deny"
+  egress         = true
+}
+
 resource "aws_network_acl_rule" "database_inbound_allow_443_rule" {
   count          = local.create_database ? 1 : 0
   network_acl_id = aws_network_acl.database[0].id
-  rule_number    = 110
+  rule_number    = 200
   cidr_block     = "0.0.0.0/0"
   protocol       = "tcp"
   from_port      = 443
@@ -1037,7 +1060,7 @@ resource "aws_network_acl_rule" "database_inbound_allow_443_rule" {
 resource "aws_network_acl_rule" "database_outbound_allow_443_rule" {
   count          = local.create_database ? 1 : 0
   network_acl_id = aws_network_acl.database[0].id
-  rule_number    = 110
+  rule_number    = 200
   cidr_block     = "0.0.0.0/0"
   protocol       = "tcp"
   from_port      = 443
@@ -1046,33 +1069,10 @@ resource "aws_network_acl_rule" "database_outbound_allow_443_rule" {
   egress         = "true"
 }
 
-resource "aws_network_acl_rule" "database_inbound_ssh_rule_deny" {
-  count          = local.create_database ? 1 : 0
-  network_acl_id = aws_network_acl.database[0].id
-  cidr_block     = "0.0.0.0/0"
-  rule_number    = 139
-  protocol       = "tcp"
-  from_port      = 22
-  to_port        = 22
-  rule_action    = "deny"
-}
-
-resource "aws_network_acl_rule" "database_outbound_ssh_rule_deny" {
-  count          = local.create_database ? 1 : 0
-  network_acl_id = aws_network_acl.database[0].id
-  rule_number    = 139
-  cidr_block     = "0.0.0.0/0"
-  protocol       = "tcp"
-  from_port      = 22
-  to_port        = 22
-  rule_action    = "deny"
-  egress         = true
-}
-
 resource "aws_network_acl_rule" "database_inbound_allow_all_ephemeral_rule" {
   count          = local.create_database ? 1 : 0
   network_acl_id = aws_network_acl.database[0].id
-  rule_number    = 140
+  rule_number    = 1000
   cidr_block     = module.vpc.vpc_cidr_block
   protocol       = "tcp"
   from_port      = 1024
@@ -1083,8 +1083,31 @@ resource "aws_network_acl_rule" "database_inbound_allow_all_ephemeral_rule" {
 resource "aws_network_acl_rule" "database_outbound_allow_all_ephemeral_rule" {
   count          = local.create_database ? 1 : 0
   network_acl_id = aws_network_acl.database[0].id
-  rule_number    = 140
+  rule_number    = 1000
   cidr_block     = module.vpc.vpc_cidr_block
+  protocol       = "tcp"
+  from_port      = 1024
+  to_port        = 65535
+  rule_action    = "allow"
+  egress         = true
+}
+
+resource "aws_network_acl_rule" "database_inbound_allow_all_ephemeral_rule_secondary_cidr" {
+  count          = local.create_intranet ? length(var.secondary_cidr_blocks) : 0
+  network_acl_id = aws_network_acl.database[0].id
+  rule_number    = 1010 + count.index
+  cidr_block     = var.secondary_cidr_blocks[count.index]
+  protocol       = "tcp"
+  from_port      = 1024
+  to_port        = 65535
+  rule_action    = "allow"
+}
+
+resource "aws_network_acl_rule" "database_outbound_allow_all_ephemeral_rule_secondary_cidr" {
+  count          = local.create_intranet ? length(var.secondary_cidr_blocks) : 0
+  network_acl_id = aws_network_acl.database[0].id
+  rule_number    = 1010 + count.index
+  cidr_block     = var.secondary_cidr_blocks[count.index]
   protocol       = "tcp"
   from_port      = 1024
   to_port        = 65535

--- a/nacl.tf
+++ b/nacl.tf
@@ -491,7 +491,7 @@ resource "aws_network_acl_rule" "private_outbound_allow_all_ephemeral_rule" {
   count          = local.create_private ? 1 : 0
   network_acl_id = aws_network_acl.private[0].id
   rule_number    = 140
-  cidr_block     = "0.0.0.0/0"
+  cidr_block     = module.vpc.vpc_cidr_block
   protocol       = "tcp"
   from_port      = 700
   to_port        = 65535
@@ -806,7 +806,7 @@ resource "aws_network_acl_rule" "intra_inbound_allow_all_ephemeral_rule" {
   count          = local.create_intranet ? 1 : 0
   network_acl_id = aws_network_acl.intra[0].id
   rule_number    = 140
-  cidr_block     = "0.0.0.0/0"
+  cidr_block     = module.vpc.vpc_cidr_block
   protocol       = "tcp"
   from_port      = 700
   to_port        = 65535
@@ -817,7 +817,7 @@ resource "aws_network_acl_rule" "intra_outbound_allow_all_ephemeral_rule" {
   count          = local.create_intranet ? 1 : 0
   network_acl_id = aws_network_acl.intra[0].id
   rule_number    = 140
-  cidr_block     = "0.0.0.0/0"
+  cidr_block     = module.vpc.vpc_cidr_block
   protocol       = "tcp"
   from_port      = 700
   to_port        = 65535
@@ -1018,7 +1018,7 @@ resource "aws_network_acl_rule" "database_inbound_allow_all_ephemeral_rule" {
   count          = local.create_database ? 1 : 0
   network_acl_id = aws_network_acl.database[0].id
   rule_number    = 140
-  cidr_block     = "0.0.0.0/0"
+  cidr_block     = module.vpc.vpc_cidr_block
   protocol       = "tcp"
   from_port      = 1024
   to_port        = 65535
@@ -1029,7 +1029,7 @@ resource "aws_network_acl_rule" "database_outbound_allow_all_ephemeral_rule" {
   count          = local.create_database ? 1 : 0
   network_acl_id = aws_network_acl.database[0].id
   rule_number    = 140
-  cidr_block     = "0.0.0.0/0"
+  cidr_block     = module.vpc.vpc_cidr_block
   protocol       = "tcp"
   from_port      = 1024
   to_port        = 65535

--- a/nacl.tf
+++ b/nacl.tf
@@ -574,7 +574,7 @@ resource "aws_network_acl_rule" "private_inbound_allow_all_ephemeral_rule" {
   rule_number    = 1100
   cidr_block     = "0.0.0.0/0"
   protocol       = "tcp"
-  from_port      = 700
+  from_port      = 1024
   to_port        = 65535
   rule_action    = "allow"
 }
@@ -585,21 +585,10 @@ resource "aws_network_acl_rule" "private_outbound_allow_all_ephemeral_rule" {
   rule_number    = 1100
   cidr_block     = module.vpc.vpc_cidr_block
   protocol       = "tcp"
-  from_port      = 700
+  from_port      = 1024
   to_port        = 65535
   rule_action    = "allow"
   egress         = "true"
-}
-
-resource "aws_network_acl_rule" "private_inbound_allow_all_ephemeral_rule_secondary_cidr" {
-  count          = local.create_private ? length(var.secondary_cidr_blocks) : 0
-  network_acl_id = aws_network_acl.private[0].id
-  rule_number    = 1110 + count.index
-  cidr_block     = var.secondary_cidr_blocks[count.index]
-  protocol       = "tcp"
-  from_port      = 700
-  to_port        = 65535
-  rule_action    = "allow"
 }
 
 resource "aws_network_acl_rule" "private_outbound_allow_all_ephemeral_rule_secondary_cidr" {
@@ -608,7 +597,7 @@ resource "aws_network_acl_rule" "private_outbound_allow_all_ephemeral_rule_secon
   rule_number    = 1110 + count.index
   cidr_block     = var.secondary_cidr_blocks[count.index]
   protocol       = "tcp"
-  from_port      = 700
+  from_port      = 1024
   to_port        = 65535
   rule_action    = "allow"
   egress         = "true"
@@ -944,9 +933,9 @@ resource "aws_network_acl_rule" "intra_inbound_allow_all_ephemeral_rule" {
   count          = local.create_intranet ? 1 : 0
   network_acl_id = aws_network_acl.intra[0].id
   rule_number    = 1100
-  cidr_block     = module.vpc.vpc_cidr_block
+  cidr_block     = "0.0.0.0/0"
   protocol       = "tcp"
-  from_port      = 700
+  from_port      = 1024
   to_port        = 65535
   rule_action    = "allow"
 }
@@ -957,21 +946,10 @@ resource "aws_network_acl_rule" "intra_outbound_allow_all_ephemeral_rule" {
   rule_number    = 1100
   cidr_block     = module.vpc.vpc_cidr_block
   protocol       = "tcp"
-  from_port      = 700
+  from_port      = 1024
   to_port        = 65535
   rule_action    = "allow"
   egress         = "true"
-}
-
-resource "aws_network_acl_rule" "intra_inbound_allow_all_ephemeral_rule_secondary_cidr" {
-  count          = local.create_intranet ? length(var.secondary_cidr_blocks) : 0
-  network_acl_id = aws_network_acl.intra[0].id
-  rule_number    = 1110 + count.index
-  cidr_block     = var.secondary_cidr_blocks[count.index]
-  protocol       = "tcp"
-  from_port      = 700
-  to_port        = 65535
-  rule_action    = "allow"
 }
 
 resource "aws_network_acl_rule" "intra_outbound_allow_all_ephemeral_rule_secondary_cidr" {
@@ -980,7 +958,7 @@ resource "aws_network_acl_rule" "intra_outbound_allow_all_ephemeral_rule_seconda
   rule_number    = 1110 + count.index
   cidr_block     = var.secondary_cidr_blocks[count.index]
   protocol       = "tcp"
-  from_port      = 700
+  from_port      = 1024
   to_port        = 65535
   rule_action    = "allow"
   egress         = "true"

--- a/nacl.tf
+++ b/nacl.tf
@@ -70,6 +70,18 @@ resource "aws_network_acl_rule" "public_inbound_rdp_rule_deny" {
   rule_action    = "deny"
 }
 
+resource "aws_network_acl_rule" "public_outbound_rdp_rule_deny" {
+  count          = local.create_public ? 1 : 0
+  network_acl_id = aws_network_acl.public[0].id
+  rule_number    = 110
+  cidr_block     = "0.0.0.0/0"
+  protocol       = "tcp"
+  from_port      = 3389
+  to_port        = 3389
+  rule_action    = "deny"
+  egress         = true
+}
+
 resource "aws_network_acl_rule" "public_inbound_rdp_rule_deny_udp" {
   count          = local.create_public ? 1 : 0
   network_acl_id = aws_network_acl.public[0].id
@@ -81,12 +93,12 @@ resource "aws_network_acl_rule" "public_inbound_rdp_rule_deny_udp" {
   rule_action    = "deny"
 }
 
-resource "aws_network_acl_rule" "public_outbound_rdp_rule_deny" {
+resource "aws_network_acl_rule" "public_outbound_rdp_rule_deny_udp" {
   count          = local.create_public ? 1 : 0
   network_acl_id = aws_network_acl.public[0].id
-  rule_number    = 110
+  rule_number    = 120
   cidr_block     = "0.0.0.0/0"
-  protocol       = "tcp"
+  protocol       = "udp"
   from_port      = 3389
   to_port        = 3389
   rule_action    = "deny"

--- a/nacl.tf
+++ b/nacl.tf
@@ -679,7 +679,7 @@ resource "aws_network_acl_rule" "intra_inbound_rdp_rule_deny" {
   count          = local.create_intranet ? 1 : 0
   network_acl_id = aws_network_acl.intra[0].id
   cidr_block     = "0.0.0.0/0"
-  rule_number    = 105
+  rule_number    = 110
   protocol       = "tcp"
   from_port      = 3389
   to_port        = 3389
@@ -689,7 +689,7 @@ resource "aws_network_acl_rule" "intra_inbound_rdp_rule_deny" {
 resource "aws_network_acl_rule" "intra_outbound_rdp_rule_deny" {
   count          = local.create_intranet ? 1 : 0
   network_acl_id = aws_network_acl.intra[0].id
-  rule_number    = 105
+  rule_number    = 110
   cidr_block     = "0.0.0.0/0"
   protocol       = "tcp"
   from_port      = 3389
@@ -701,7 +701,7 @@ resource "aws_network_acl_rule" "intra_outbound_rdp_rule_deny" {
 resource "aws_network_acl_rule" "intranet_inbound_allow_443_rule" {
   count          = local.create_intranet ? 1 : 0
   network_acl_id = aws_network_acl.intra[0].id
-  rule_number    = 110
+  rule_number    = 200
   cidr_block     = "0.0.0.0/0"
   protocol       = "tcp"
   from_port      = 443
@@ -712,7 +712,7 @@ resource "aws_network_acl_rule" "intranet_inbound_allow_443_rule" {
 resource "aws_network_acl_rule" "intranet_outbound_allow_443_rule" {
   count          = local.create_intranet ? 1 : 0
   network_acl_id = aws_network_acl.intra[0].id
-  rule_number    = 110
+  rule_number    = 200
   cidr_block     = "0.0.0.0/0"
   protocol       = "tcp"
   from_port      = 443
@@ -724,7 +724,7 @@ resource "aws_network_acl_rule" "intranet_outbound_allow_443_rule" {
 resource "aws_network_acl_rule" "intranet_inbound_nfs_111_rule" {
   count          = local.create_intranet ? 1 : 0
   network_acl_id = aws_network_acl.intra[0].id
-  rule_number    = 115
+  rule_number    = 210
   cidr_block     = module.vpc.vpc_cidr_block
   protocol       = "tcp"
   from_port      = 111
@@ -735,7 +735,7 @@ resource "aws_network_acl_rule" "intranet_inbound_nfs_111_rule" {
 resource "aws_network_acl_rule" "intranet_outbound_nfs_111_rule" {
   count          = local.create_intranet ? 1 : 0
   network_acl_id = aws_network_acl.intra[0].id
-  rule_number    = 115
+  rule_number    = 210
   cidr_block     = module.vpc.vpc_cidr_block
   protocol       = "tcp"
   from_port      = 111
@@ -747,7 +747,7 @@ resource "aws_network_acl_rule" "intranet_outbound_nfs_111_rule" {
 resource "aws_network_acl_rule" "intranet_inbound_nfs_111_rule_secondary_cidr" {
   count          = local.create_intranet ? length(var.secondary_cidr_blocks) : 0
   network_acl_id = aws_network_acl.intra[0].id
-  rule_number    = 116 + count.index
+  rule_number    = 220 + count.index
   cidr_block     = var.secondary_cidr_blocks[count.index]
   protocol       = "tcp"
   from_port      = 111
@@ -758,7 +758,7 @@ resource "aws_network_acl_rule" "intranet_inbound_nfs_111_rule_secondary_cidr" {
 resource "aws_network_acl_rule" "intranet_outbound_nfs_111_rule_secondary_cidr" {
   count          = local.create_intranet ? length(var.secondary_cidr_blocks) : 0
   network_acl_id = aws_network_acl.intra[0].id
-  rule_number    = 116 + count.index
+  rule_number    = 220 + count.index
   cidr_block     = var.secondary_cidr_blocks[count.index]
   protocol       = "tcp"
   from_port      = 111
@@ -770,7 +770,7 @@ resource "aws_network_acl_rule" "intranet_outbound_nfs_111_rule_secondary_cidr" 
 resource "aws_network_acl_rule" "intranet_inbound_ssh_rule" {
   count          = local.create_intranet ? 1 : 0
   network_acl_id = aws_network_acl.intra[0].id
-  rule_number    = 120
+  rule_number    = 230
   cidr_block     = module.vpc.vpc_cidr_block
   protocol       = "tcp"
   from_port      = 22
@@ -781,7 +781,7 @@ resource "aws_network_acl_rule" "intranet_inbound_ssh_rule" {
 resource "aws_network_acl_rule" "intranet_outbound_ssh_rule" {
   count          = local.create_intranet ? 1 : 0
   network_acl_id = aws_network_acl.intra[0].id
-  rule_number    = 120
+  rule_number    = 230
   cidr_block     = module.vpc.vpc_cidr_block
   protocol       = "tcp"
   from_port      = 22
@@ -793,7 +793,7 @@ resource "aws_network_acl_rule" "intranet_outbound_ssh_rule" {
 resource "aws_network_acl_rule" "intranet_inbound_ssh_rule_secondary_cidr" {
   count          = local.create_intranet ? length(var.secondary_cidr_blocks) : 0
   network_acl_id = aws_network_acl.intra[0].id
-  rule_number    = 121 + count.index
+  rule_number    = 240 + count.index
   cidr_block     = var.secondary_cidr_blocks[count.index]
   protocol       = "tcp"
   from_port      = 22
@@ -804,7 +804,7 @@ resource "aws_network_acl_rule" "intranet_inbound_ssh_rule_secondary_cidr" {
 resource "aws_network_acl_rule" "intranet_outbound_ssh_rule_secondary_cidr" {
   count          = local.create_intranet ? length(var.secondary_cidr_blocks) : 0
   network_acl_id = aws_network_acl.intra[0].id
-  rule_number    = 121 + count.index
+  rule_number    = 240 + count.index
   cidr_block     = var.secondary_cidr_blocks[count.index]
   protocol       = "tcp"
   from_port      = 22
@@ -816,8 +816,8 @@ resource "aws_network_acl_rule" "intranet_outbound_ssh_rule_secondary_cidr" {
 resource "aws_network_acl_rule" "intra_inbound_ssh_rule_deny" {
   count          = local.create_intranet ? 1 : 0
   network_acl_id = aws_network_acl.intra[0].id
+  rule_number    = 250
   cidr_block     = "0.0.0.0/0"
-  rule_number    = 139
   protocol       = "tcp"
   from_port      = 22
   to_port        = 22
@@ -827,7 +827,7 @@ resource "aws_network_acl_rule" "intra_inbound_ssh_rule_deny" {
 resource "aws_network_acl_rule" "intra_outbound_ssh_rule_deny" {
   count          = local.create_intranet ? 1 : 0
   network_acl_id = aws_network_acl.intra[0].id
-  rule_number    = 139
+  rule_number    = 250
   cidr_block     = "0.0.0.0/0"
   protocol       = "tcp"
   from_port      = 22
@@ -836,103 +836,10 @@ resource "aws_network_acl_rule" "intra_outbound_ssh_rule_deny" {
   egress         = true
 }
 
-resource "aws_network_acl_rule" "intra_inbound_allow_all_ephemeral_rule" {
-  count          = local.create_intranet ? 1 : 0
-  network_acl_id = aws_network_acl.intra[0].id
-  rule_number    = 140
-  cidr_block     = module.vpc.vpc_cidr_block
-  protocol       = "tcp"
-  from_port      = 700
-  to_port        = 65535
-  rule_action    = "allow"
-}
-
-resource "aws_network_acl_rule" "intra_outbound_allow_all_ephemeral_rule" {
-  count          = local.create_intranet ? 1 : 0
-  network_acl_id = aws_network_acl.intra[0].id
-  rule_number    = 140
-  cidr_block     = module.vpc.vpc_cidr_block
-  protocol       = "tcp"
-  from_port      = 700
-  to_port        = 65535
-  rule_action    = "allow"
-  egress         = "true"
-}
-
-resource "aws_network_acl_rule" "intra_inbound_allow_all_udp" {
-  count          = local.create_intranet ? 1 : 0
-  network_acl_id = aws_network_acl.intra[0].id
-  rule_number    = 141
-  cidr_block     = module.vpc.vpc_cidr_block
-  protocol       = "udp"
-  from_port      = 1
-  to_port        = 65535
-  rule_action    = "allow"
-}
-
-resource "aws_network_acl_rule" "intra_outbound_allow_all_udp" {
-  count          = local.create_intranet ? 1 : 0
-  network_acl_id = aws_network_acl.intra[0].id
-  rule_number    = 141
-  cidr_block     = module.vpc.vpc_cidr_block
-  protocol       = "udp"
-  from_port      = 1
-  to_port        = 65535
-  rule_action    = "allow"
-  egress         = "true"
-}
-
-resource "aws_network_acl_rule" "intra_inbound_allow_all_udp_secondary_cidr" {
-  count          = local.create_intranet ? length(var.secondary_cidr_blocks) : 0
-  network_acl_id = aws_network_acl.intra[0].id
-  rule_number    = 142 + count.index
-  cidr_block     = var.secondary_cidr_blocks[count.index]
-  protocol       = "udp"
-  from_port      = 1
-  to_port        = 65535
-  rule_action    = "allow"
-}
-
-resource "aws_network_acl_rule" "intra_outbound_allow_all_udp_secondary_cidr" {
-  count          = local.create_intranet ? length(var.secondary_cidr_blocks) : 0
-  network_acl_id = aws_network_acl.intra[0].id
-  rule_number    = 142 + count.index
-  cidr_block     = var.secondary_cidr_blocks[count.index]
-  protocol       = "udp"
-  from_port      = 1
-  to_port        = 65535
-  rule_action    = "allow"
-  egress         = true
-}
-
-resource "aws_network_acl_rule" "intra_inbound_allow_tcp_dns" {
-  count          = local.create_intranet ? 1 : 0
-  network_acl_id = aws_network_acl.intra[0].id
-  rule_number    = 147
-  cidr_block     = "0.0.0.0/0"
-  protocol       = "tcp"
-  from_port      = 53
-  to_port        = 53
-  rule_action    = "allow"
-}
-
-resource "aws_network_acl_rule" "intra_outbound_allow_tcp_dns" {
-  count          = local.create_intranet ? 1 : 0
-  network_acl_id = aws_network_acl.intra[0].id
-  rule_number    = 147
-  cidr_block     = "0.0.0.0/0"
-  protocol       = "tcp"
-  from_port      = 53
-  to_port        = 53
-  rule_action    = "allow"
-  egress         = "true"
-}
-
-
 resource "aws_network_acl_rule" "intranet_inbound_bgp_179_rule" {
   count          = local.create_intranet ? 1 : 0
   network_acl_id = aws_network_acl.intra[0].id
-  rule_number    = 153
+  rule_number    = 910
   cidr_block     = module.vpc.vpc_cidr_block
   protocol       = "tcp"
   from_port      = 179
@@ -943,7 +850,7 @@ resource "aws_network_acl_rule" "intranet_inbound_bgp_179_rule" {
 resource "aws_network_acl_rule" "intranet_outbound_bgp_179_rule" {
   count          = local.create_intranet ? 1 : 0
   network_acl_id = aws_network_acl.intra[0].id
-  rule_number    = 153
+  rule_number    = 910
   cidr_block     = module.vpc.vpc_cidr_block
   protocol       = "tcp"
   from_port      = 179
@@ -955,7 +862,7 @@ resource "aws_network_acl_rule" "intranet_outbound_bgp_179_rule" {
 resource "aws_network_acl_rule" "intranet_inbound_bgp_179_rule_secondary_cidr" {
   count          = local.create_intranet ? length(var.secondary_cidr_blocks) : 0
   network_acl_id = aws_network_acl.intra[0].id
-  rule_number    = 154 + count.index
+  rule_number    = 920 + count.index
   cidr_block     = var.secondary_cidr_blocks[count.index]
   protocol       = "tcp"
   from_port      = 179
@@ -966,7 +873,7 @@ resource "aws_network_acl_rule" "intranet_inbound_bgp_179_rule_secondary_cidr" {
 resource "aws_network_acl_rule" "intranet_outbound_bgp_179_rule_secondary_cidr" {
   count          = local.create_intranet ? length(var.secondary_cidr_blocks) : 0
   network_acl_id = aws_network_acl.intra[0].id
-  rule_number    = 154 + count.index
+  rule_number    = 920 + count.index
   cidr_block     = var.secondary_cidr_blocks[count.index]
   protocol       = "tcp"
   from_port      = 179
@@ -975,6 +882,120 @@ resource "aws_network_acl_rule" "intranet_outbound_bgp_179_rule_secondary_cidr" 
   egress         = true
 }
 
+resource "aws_network_acl_rule" "intra_inbound_allow_all_udp" {
+  count          = local.create_intranet ? 1 : 0
+  network_acl_id = aws_network_acl.intra[0].id
+  rule_number    = 1000
+  cidr_block     = module.vpc.vpc_cidr_block
+  protocol       = "udp"
+  from_port      = 1
+  to_port        = 65535
+  rule_action    = "allow"
+}
+
+resource "aws_network_acl_rule" "intra_outbound_allow_all_udp" {
+  count          = local.create_intranet ? 1 : 0
+  network_acl_id = aws_network_acl.intra[0].id
+  rule_number    = 1000
+  cidr_block     = module.vpc.vpc_cidr_block
+  protocol       = "udp"
+  from_port      = 1
+  to_port        = 65535
+  rule_action    = "allow"
+  egress         = "true"
+}
+
+resource "aws_network_acl_rule" "intra_inbound_allow_all_udp_secondary_cidr" {
+  count          = local.create_intranet ? length(var.secondary_cidr_blocks) : 0
+  network_acl_id = aws_network_acl.intra[0].id
+  rule_number    = 1010 + count.index
+  cidr_block     = var.secondary_cidr_blocks[count.index]
+  protocol       = "udp"
+  from_port      = 1
+  to_port        = 65535
+  rule_action    = "allow"
+}
+
+resource "aws_network_acl_rule" "intra_outbound_allow_all_udp_secondary_cidr" {
+  count          = local.create_intranet ? length(var.secondary_cidr_blocks) : 0
+  network_acl_id = aws_network_acl.intra[0].id
+  rule_number    = 1010 + count.index
+  cidr_block     = var.secondary_cidr_blocks[count.index]
+  protocol       = "udp"
+  from_port      = 1
+  to_port        = 65535
+  rule_action    = "allow"
+  egress         = true
+}
+
+resource "aws_network_acl_rule" "intra_inbound_allow_all_ephemeral_rule" {
+  count          = local.create_intranet ? 1 : 0
+  network_acl_id = aws_network_acl.intra[0].id
+  rule_number    = 1100
+  cidr_block     = module.vpc.vpc_cidr_block
+  protocol       = "tcp"
+  from_port      = 700
+  to_port        = 65535
+  rule_action    = "allow"
+}
+
+resource "aws_network_acl_rule" "intra_outbound_allow_all_ephemeral_rule" {
+  count          = local.create_intranet ? 1 : 0
+  network_acl_id = aws_network_acl.intra[0].id
+  rule_number    = 1100
+  cidr_block     = module.vpc.vpc_cidr_block
+  protocol       = "tcp"
+  from_port      = 700
+  to_port        = 65535
+  rule_action    = "allow"
+  egress         = "true"
+}
+
+resource "aws_network_acl_rule" "intra_inbound_allow_all_ephemeral_rule_secondary_cidr" {
+  count          = local.create_intranet ? length(var.secondary_cidr_blocks) : 0
+  network_acl_id = aws_network_acl.intra[0].id
+  rule_number    = 1110 + count.index
+  cidr_block     = var.secondary_cidr_blocks[count.index]
+  protocol       = "tcp"
+  from_port      = 700
+  to_port        = 65535
+  rule_action    = "allow"
+}
+
+resource "aws_network_acl_rule" "intra_outbound_allow_all_ephemeral_rule_secondary_cidr" {
+  count          = local.create_intranet ? length(var.secondary_cidr_blocks) : 0
+  network_acl_id = aws_network_acl.intra[0].id
+  rule_number    = 1110 + count.index
+  cidr_block     = var.secondary_cidr_blocks[count.index]
+  protocol       = "tcp"
+  from_port      = 700
+  to_port        = 65535
+  rule_action    = "allow"
+  egress         = "true"
+}
+
+resource "aws_network_acl_rule" "intra_inbound_allow_tcp_dns" {
+  count          = local.create_intranet ? 1 : 0
+  network_acl_id = aws_network_acl.intra[0].id
+  rule_number    = 1200
+  cidr_block     = "0.0.0.0/0"
+  protocol       = "tcp"
+  from_port      = 53
+  to_port        = 53
+  rule_action    = "allow"
+}
+
+resource "aws_network_acl_rule" "intra_outbound_allow_tcp_dns" {
+  count          = local.create_intranet ? 1 : 0
+  network_acl_id = aws_network_acl.intra[0].id
+  rule_number    = 1200
+  cidr_block     = "0.0.0.0/0"
+  protocol       = "tcp"
+  from_port      = 53
+  to_port        = 53
+  rule_action    = "allow"
+  egress         = "true"
+}
 
 ###########################
 # Database subnet ACL


### PR DESCRIPTION
Scoping down the NACL for private and intranet subnets to VPC CIDR as a result of a VAPT finding.

Changes:
- rearranged the rule numbers so that they are spaced out by at least 10 [aws doc](https://docs.aws.amazon.com/vpc/latest/userguide/vpc-network-acls.html#:~:text=we%20recommend%20that%20you%20start%20by%20creating%20rules%20in%20increments%20(for%20example%2C%20increments%20of%2010%20or%20100)%20so%20that%20you%20can%20insert%20new%20rules%20later%20on%2C%20if%20needed.)
- > We recommend that you start by creating rules in increments (for example, increments of 10 or 100) so that you can insert new rules later on, if needed.
- pattern for rule numbers
  - 100-199: port explicit deny
  - 200-900: port explicit allow
  - 1000+: port range allow
- outbound (genereally) can be scoped down to VPC CIDR with no issues
  - outbound for intra needs `32768-61000` `0.0.0.0/0` to allow transit gateway (GEN connectivity) to work
- inbound ephemeral ports `1024-65535` still need to allow `0.0.0.0/0` else some AWS service breaks [closest aws doc that explains this](https://docs.aws.amazon.com/vpc/latest/userguide/vpc-network-acls.html#nacl-ephemeral-ports)
  - ECS unable to pull from ECR
  - SSM session manager unable to reach S3
