### PR TITLE
allow input for log group filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,6 +324,8 @@ No requirements.
 | [aws_security_group.allow_443](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
 | [aws_security_group.allow_http_https_outgoing](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
 | [aws_availability_zones.available](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/availability_zones) | data source |
+| [aws_network_acls.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/network_acls) | data source |
+| [aws_cloudwatch_log_subscription_filter.flow_log](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_subscription_filter) | resource |
 
 ## Inputs
 
@@ -407,6 +409,7 @@ No requirements.
 | <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | VPC id for use in cases where VPC was already created and you would like to reuse it with this module. Not required if create\_vpc = true | `string` | `""` | no |
 | <a name="input_vpc_name"></a> [vpc\_name](#input\_vpc\_name) | Name of VPC | `string` | n/a | yes |
 | <a name="input_vpc_tags"></a> [vpc\_tags](#input\_vpc\_tags) | Tags to apply to VPC | `map(any)` | `{}` | no |
+| <a name="input_lg_filters"></a> [lg\_filters](#input\_lg\_filters) | Log group filters to create for Network Firewall logs | <pre>map(object({<br> naming_suffix = string<br> role_arn = string<br> filter_pattern = string<br> destination_arn = string<br> distribution = string<br>}))</pre> | `{}` | no |
 
 ## Outputs
 

--- a/variables.tf
+++ b/variables.tf
@@ -258,6 +258,18 @@ variable "vpc_flow_log_tags" {
   default     = {}
 }
 
+variable "lg_filters" {
+  description = "Log group filters for Network Firewall"
+  type = map(object({
+    naming_suffix   = string
+    role_arn        = string
+    filter_pattern  = string
+    destination_arn = string
+    distribution    = string
+  }))
+  default = {}
+}
+
 ################################################################################
 # Flow Log CloudWatch
 ################################################################################


### PR DESCRIPTION
Idea behind this MR is to bring the log subs filter side by side the log group instead of having it in a separate module (We always end up forgetting to apply this downstream resource in CX resulting in a lot of gaps in the logs streamed to other places). So it dies or lives alongside the module. Tested with no input - it falls back to the empty map so no changes. 
