### PR TITLE
feat: add eks specific tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,46 @@ As this module was originalyl intended to create 1 vpc with 1 cidr range for man
 > terragrunt import 'module.vpc.aws_vpc_ipv4_cidr_block_association.this[0]' vpc-cidr-assoc-xxx
 > terragrunt import 'module.vpc.aws_internet_gateway.this[0]' igw-xxx
 
+### EKS Subnet-Specific Tags
+
+With the introduction of subnet-specific EKS tag variables, you can now apply different tags to different subnet types. This is useful when you need specific tags for different subnet types for EKS cluster requirements or organizational purposes.
+
+```hcl
+module "vpc" {
+  vpc_cidr = "172.1.1.0/25"
+
+  # General EKS cluster tags applied to all subnets
+  eks_cluster_tags = {
+    "kubernetes.io/cluster/my-cluster" = "shared"
+  }
+
+  # Public subnet specific EKS tags
+  eks_public_subnet_tags = {
+    "kubernetes.io/cluster/my-cluster" = "owned"
+    "Environment" = "production"
+  }
+
+  # Private subnet specific EKS tags
+  eks_private_subnet_tags = {
+    "kubernetes.io/cluster/my-cluster" = "owned"
+    "Tier" = "application"
+  }
+
+  # Intra subnet specific EKS tags
+  eks_intra_subnet_tags = {
+    "Tier" = "management"
+  }
+
+  public_subnets = ["172.1.1.0/27"]
+  private_subnets = ["172.1.1.32/27"]
+  intranet_subnets = ["172.1.1.64/27"]
+  database_subnets = ["172.1.1.96/27"]
+  number_of_azs = 2
+}
+```
+
+**Note**: The subnet-specific tags are merged with the general `eks_cluster_tags`, so you don't need to repeat common tags across all subnet types.
+
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 
@@ -359,6 +399,10 @@ No requirements.
 | <a name="input_default_vpc_name"></a> [default\_vpc\_name](#input\_default\_vpc\_name) | Name to be used on the Default VPC | `string` | `null` | no |
 | <a name="input_default_vpc_tags"></a> [default\_vpc\_tags](#input\_default\_vpc\_tags) | Additional tags for the Default VPC | `map(string)` | `{}` | no |
 | <a name="input_eks_cluster_tags"></a> [eks\_cluster\_tags](#input\_eks\_cluster\_tags) | List of tags that EKS will create, but also added to VPC for persistency across terraform applies | `map(any)` | `{}` | no |
+| <a name="input_eks_database_subnet_tags"></a> [eks\_database\_subnet\_tags](#input\_eks\_database\_subnet\_tags) | Additional EKS-specific tags to apply to database subnets only | `map(any)` | `{}` | no |
+| <a name="input_eks_intra_subnet_tags"></a> [eks\_intra\_subnet\_tags](#input\_eks\_intra\_subnet\_tags) | Additional EKS-specific tags to apply to intra subnets only | `map(any)` | `{}` | no |
+| <a name="input_eks_private_subnet_tags"></a> [eks\_private\_subnet\_tags](#input\_eks\_private\_subnet\_tags) | Additional EKS-specific tags to apply to private subnets only | `map(any)` | `{}` | no |
+| <a name="input_eks_public_subnet_tags"></a> [eks\_public\_subnet\_tags](#input\_eks\_public\_subnet\_tags) | Additional EKS-specific tags to apply to public subnets only | `map(any)` | `{}` | no |
 | <a name="input_enable_flow_log"></a> [enable\_flow\_log](#input\_enable\_flow\_log) | Whether or not to enable VPC Flow Logs | `bool` | `false` | no |
 | <a name="input_enable_nat_gateway"></a> [enable\_nat\_gateway](#input\_enable\_nat\_gateway) | Should be true if you want to provision NAT Gateways for each of your private networks | `bool` | `true` | no |
 | <a name="input_firewall_dedicated_network_acl"></a> [firewall\_dedicated\_network\_acl](#input\_firewall\_dedicated\_network\_acl) | Whether to use dedicated network ACL (not default) and custom rules for firewall subnets | `bool` | `false` | no |

--- a/main.tf
+++ b/main.tf
@@ -14,7 +14,7 @@ locals {
   vpc_tags = merge(var.vpc_tags)
 
   vpc_flow_log_name_chunks = split(":", module.vpc.vpc_flow_log_destination_arn)
-  vpc_flow_log_name = local.vpc_flow_log_name_chunks[length(local.vpc_flow_log_name_chunks) - 1]
+  vpc_flow_log_name        = local.vpc_flow_log_name_chunks[length(local.vpc_flow_log_name_chunks) - 1]
 }
 
 # creates the elastic IPs which the NAT gateways are allocated
@@ -41,6 +41,7 @@ module "vpc" {
 
   public_subnet_tags = merge(
     var.eks_cluster_tags,
+    var.eks_public_subnet_tags,
     {
       "kubernetes.io/role/elb" = "1",
       "AccessType"             = "internet ingress/egress"
@@ -77,6 +78,7 @@ module "vpc" {
 
   private_subnet_tags = merge(
     var.eks_cluster_tags,
+    var.eks_private_subnet_tags,
     {
       "kubernetes.io/role/internal-elb" = "1",
       "AccessType"                      = "internet egress"
@@ -91,6 +93,7 @@ module "vpc" {
 
   intra_subnet_tags = merge(
     var.eks_cluster_tags,
+    var.eks_intra_subnet_tags,
     {
       "AccessType" = "intranet"
     }
@@ -237,7 +240,7 @@ resource "aws_security_group" "allow_http_https_outgoing" {
 }
 
 #######################
-# Flow Logs 
+# Flow Logs
 #######################
 
 resource "aws_cloudwatch_log_subscription_filter" "flow_log" {

--- a/variables.tf
+++ b/variables.tf
@@ -55,6 +55,24 @@ variable "eks_cluster_tags" {
   default     = {}
 }
 
+variable "eks_public_subnet_tags" {
+  description = "Additional EKS-specific tags to apply to public subnets only"
+  type        = map(any)
+  default     = {}
+}
+
+variable "eks_private_subnet_tags" {
+  description = "Additional EKS-specific tags to apply to private subnets only"
+  type        = map(any)
+  default     = {}
+}
+
+variable "eks_intra_subnet_tags" {
+  description = "Additional EKS-specific tags to apply to intra subnets only"
+  type        = map(any)
+  default     = {}
+}
+
 variable "number_of_azs" {
   description = "Determines number of availability zones to use in the region"
   default     = 2


### PR DESCRIPTION
## Add Subnet-Specific EKS Tags Support

### Summary
This PR introduces subnet-specific EKS tag variables alongside the existing `eks_cluster_tags`, allowing for more granular tagging of different subnet types in VPC configurations.

### Changes Made

#### New Variables Added
- `eks_public_subnet_tags` - Additional EKS-specific tags to apply to public subnets only
- `eks_private_subnet_tags` - Additional EKS-specific tags to apply to private subnets only  
- `eks_intra_subnet_tags` - Additional EKS-specific tags to apply to intra subnets only

#### Implementation Details
- **Backward Compatible**: Existing `eks_cluster_tags` functionality remains unchanged
- **Merged Approach**: New subnet-specific tags are merged with the general `eks_cluster_tags`
- **Optional**: All new variables have empty default values (`{}`)
- **Type Safe**: All new variables use `map(any)` type for consistency

#### Files Modified
1. **variables.tf**: Added three new optional variables for subnet-specific EKS tags
2. **main.tf**: Updated subnet tag configurations to merge general and specific tags:
   - Public subnets: `merge(var.eks_cluster_tags, var.eks_public_subnet_tags, {...})`
   - Private subnets: `merge(var.eks_cluster_tags, var.eks_private_subnet_tags, {...})`
   - Intra subnets: `merge(var.eks_cluster_tags, var.eks_intra_subnet_tags, {...})`
3. **README.md**: Added comprehensive documentation and usage examples

### Benefits
- **Fine-grained Control**: Apply different tags to different subnet types
- **EKS Compliance**: Better support for EKS cluster requirements that may differ by subnet type
- **Organizational Flexibility**: Support different governance/organizational tagging needs per subnet type
- **Maintains Simplicity**: Common tags can still be applied via the existing `eks_cluster_tags`

### Usage Example
```hcl
module "vpc" {
  # General EKS cluster tags applied to all subnets
  eks_cluster_tags = {
    "kubernetes.io/cluster/my-cluster" = "shared"
  }
  
  # Public subnet specific EKS tags
  eks_public_subnet_tags = {
    "kubernetes.io/cluster/my-cluster" = "owned"
    "Environment" = "production"
  }
  
  # Private subnet specific EKS tags
  eks_private_subnet_tags = {
    "Tier" = "application"
  }
  
  # Intra subnet specific EKS tags  
  eks_intra_subnet_tags = {
    "Tier" = "management"
  }
  
  # ... other configuration
}